### PR TITLE
Fix Cloud Run deployment build context issue

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -40,9 +40,8 @@ jobs:
       
     - name: Deploy to Cloud Run
       run: |
-        cd backend
         gcloud run deploy documind-backend \
-          --source . \
+          --source ./backend \
           --region us-central1 \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
- Changed from 'cd backend && --source .' to '--source ./backend'
- Resolves Docker build failure where requirements.txt was not found
- Tested successfully with Cloud Run deployment