### PR TITLE
Fix Cloud Run deployment with explicit Docker build approach - Change…

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -38,10 +38,17 @@ jobs:
     - name: Configure Docker for Google Cloud
       run: gcloud auth configure-docker
       
-    - name: Deploy to Cloud Run
+    - name: Build and Deploy to Cloud Run
       run: |
+        # Build the Docker image
+        docker build -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend ./backend
+        
+        # Push the image to Google Container Registry
+        docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend
+        
+        # Deploy to Cloud Run using the pushed image
         gcloud run deploy documind-backend \
-          --source ./backend \
+          --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend \
           --region us-central1 \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
…d from --source deployment to explicit Docker build and push - Build Docker image from ./backend directory with proper context - Push to Google Container Registry then deploy from image - This should resolve the persistent requirements.txt build context issue