### PR TITLE
Fix Docker image tag by using dynamic project ID

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -40,15 +40,18 @@ jobs:
       
     - name: Build and Deploy to Cloud Run
       run: |
+        # Get the project ID from gcloud config
+        PROJECT_ID=$(gcloud config get-value project)
+        
         # Build the Docker image
-        docker build -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend ./backend
+        docker build -t gcr.io/$PROJECT_ID/documind-backend ./backend
         
         # Push the image to Google Container Registry
-        docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend
+        docker push gcr.io/$PROJECT_ID/documind-backend
         
         # Deploy to Cloud Run using the pushed image
         gcloud run deploy documind-backend \
-          --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/documind-backend \
+          --image gcr.io/$PROJECT_ID/documind-backend \
           --region us-central1 \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
- Replace missing GCP_PROJECT_ID secret with gcloud config get-value project
- This resolves the invalid Docker tag gcr.io//documind-backend error
- Uses the project ID already configured in GitHub Actions environment
- Should allow successful Docker build and push to GCR