### PR TITLE
Fix Docker push permissions by switching to Artifact Registry

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -36,7 +36,9 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
         
     - name: Configure Docker for Google Cloud
-      run: gcloud auth configure-docker
+      run: |
+        gcloud auth configure-docker
+        gcloud auth configure-docker us-central1-docker.pkg.dev
       
     - name: Build and Deploy to Cloud Run
       run: |
@@ -55,16 +57,16 @@ jobs:
         
         # Build the Docker image with verbose output
         echo "Building Docker image..."
-        docker build -t gcr.io/$PROJECT_ID/documind-backend ./backend --progress=plain
+        docker build -t us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/documind-backend ./backend --progress=plain
         
-        # Push the image to Google Container Registry
+        # Push the image to Artifact Registry
         echo "Pushing Docker image..."
-        docker push gcr.io/$PROJECT_ID/documind-backend
+        docker push us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/documind-backend
         
         # Deploy to Cloud Run using the pushed image
         echo "Deploying to Cloud Run..."
         gcloud run deploy documind-backend \
-          --image gcr.io/$PROJECT_ID/documind-backend \
+          --image us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/documind-backend \
           --region us-central1 \
           --platform managed \
           --allow-unauthenticated \


### PR DESCRIPTION
- Changed from gcr.io to us-central1-docker.pkg.dev/PROJECT_ID/cloud-run-source-deploy
- Added Artifact Registry authentication to Docker configuration
- This should resolve the 'denied: gcr.io repo does not exist' permission error
- Docker build was successful, now fixing the push step